### PR TITLE
Fixing swapped variables in CharacterEntry

### DIFF
--- a/src/parse_master.py
+++ b/src/parse_master.py
@@ -821,8 +821,8 @@ class CharacterEntry(BaseEntry):
 		# Added 3/5/2018. When non-zero, points to the character ID of what this
 		# character would become after being rarity grown.
 		'rarityGrownID',
-		'canRarityGrow', # Added 3/12/2018.
 		'isRarityGrown', # Added 3/12/2018.
+		'canRarityGrow', # Added 3/12/2018.
 		]
 
 	def __init__(my, data_entry_csv):


### PR DESCRIPTION
The canRarityGrow and isRarityGrown turns out to be swapped after comparing expected values to the rarityGrownID entry. All ID values indicated by rarityGrownID should have the isRarityGrown value at '1', and after checking entries for Flower Knights with the last entry at the value of '1' being either bloomed golds or evolved low-rarity Knights rather than the rainbow-growth Flower Knights, it was determined that the aforementioned values are mistakenly swapped.